### PR TITLE
feat: finalize Decap CMS setup with previews

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,73 +1,91 @@
 backend:
-  name: git-gateway # oder 'github' falls direkt via GitHub OAuth
+  name: github
+  repo: alexle135/alexle-vsco
   branch: main
+  base_url: https://alexle135.de
+  auth_endpoint: api/auth
   commit_messages:
-    create: 'feat(cms): create {{collection}} “{{slug}}”'
-    update: 'chore(cms): update {{collection}} “{{slug}}”'
-    delete: 'chore(cms): delete {{collection}} “{{slug}}”'
-    uploadMedia: 'chore(media): upload “{{path}}”'
-    deleteMedia: 'chore(media): delete “{{path}}”'
+    create: 'feat(cms): create {{collection}} "{{slug}}"'
+    update: 'chore(cms): update {{collection}} "{{slug}}"'
+    delete: 'chore(cms): delete {{collection}} "{{slug}}"'
+    uploadMedia: 'chore(media): upload "{{path}}"'
+    deleteMedia: 'chore(media): delete "{{path}}"'
 local_backend: true
 publish_mode: editorial_workflow
+site_url: https://alexle135.de
 media_folder: public/media/uploads
 public_folder: /media/uploads
+slug:
+  encoding: unicode
+  clean_accents: true
 
 collections:
   - name: hero
-    label: Hero
+    label: Hero Bereich
     format: json
     delete: false
     editor:
-      preview: false
+      preview: true
     files:
-      - file: src/content/site/hero.json
-        label: Hero Content
+      - file: src/content/hero/hero.json
+        label: Hero Inhalt
         name: hero
         fields:
           - { name: title, label: Titel, widget: string }
-          - { name: subtitle, label: Untertitel, widget: string, required: false }
+          - { name: subtitle, label: Untertitel, widget: text, required: false }
           - { name: cta, label: CTA-Text, widget: string, required: false }
           - { name: media, label: Medien (Bild/Video-URL), widget: string, required: false }
 
   - name: about
     label: Über mich
     delete: false
+    editor:
+      preview: true
     files:
-      - file: src/content/site/about.md
-        label: Über mich Text
+      - file: src/content/about/about.md
+        label: Über mich Inhalt
         name: about
         fields:
           - { name: title, label: Titel, widget: string }
+          - { name: profileImage, label: Profilbild, widget: image, required: false }
+          - { name: profileImageAlt, label: Alt-Text, widget: string, required: false }
           - { name: body, label: Inhalt, widget: markdown }
 
   - name: services
     label: Services
     format: json
+    editor:
+      preview: true
     files:
-      - file: src/content/site/services.json
-        label: Services Liste
+      - file: src/content/services/services.json
+        label: Service Liste
         name: services
         fields:
           - label: Services
             name: items
             widget: list
+            summary: '{{fields.title}}'
             fields:
               - { name: title, label: Titel, widget: string }
-              - { name: description, label: Beschreibung, widget: string }
+              - { name: description, label: Beschreibung, widget: text }
               - { name: icon, label: Icon (Klasse/Name), widget: string, required: false }
+              - { name: color, label: Farbkennung, widget: string, required: false }
               - { name: tags, label: Tags, widget: list, required: false }
 
   - name: skills
     label: Skills
     format: json
+    editor:
+      preview: true
     files:
-      - file: src/content/site/skills.json
-        label: Skillliste
+      - file: src/content/skills/skills.json
+        label: Skill Liste
         name: skills
         fields:
           - label: Skills
             name: items
             widget: list
+            summary: '{{fields.name}} – {{fields.percentage}}%'
             fields:
               - { name: name, label: Name, widget: string }
               - { name: percentage, label: Prozent, widget: number, value_type: int, min: 0, max: 100 }
@@ -77,13 +95,14 @@ collections:
     label: Projekte
     folder: src/content/projects
     create: true
-    slug: "{{slug}}"
-    extension: md
+    slug: '{{slug}}'
     format: frontmatter
+    editor:
+      preview: true
     fields:
       - { name: title, label: Titel, widget: string }
-      - { name: date, label: Datum, widget: datetime, required: false }
       - { name: summary, label: Kurzbeschreibung, widget: text }
+      - { name: date, label: Datum, widget: datetime, required: false }
       - { name: tags, label: Tags, widget: list, required: false }
       - { name: heroImage, label: Hero-Bild, widget: image, required: false }
       - { name: repo, label: Repository-URL, widget: string, required: false }
@@ -93,16 +112,51 @@ collections:
   - name: legal
     label: Rechtliches
     delete: false
+    editor:
+      preview: true
     files:
       - file: src/content/legal/impressum.md
         label: Impressum
         name: impressum
         fields:
-          - { name: title, label: Titel, widget: string, default: Impressum }
+          - { name: title, label: Titel, widget: string, default: 'Impressum' }
           - { name: body, label: Inhalt, widget: markdown }
       - file: src/content/legal/datenschutz.md
         label: Datenschutzerklärung
         name: datenschutz
         fields:
-          - { name: title, label: Titel, widget: string, default: Datenschutzerklärung }
+          - { name: title, label: Titel, widget: string, default: 'Datenschutzerklärung' }
           - { name: body, label: Inhalt, widget: markdown }
+
+  - name: ki-news
+    label: KI News Feed
+    format: json
+    delete: false
+    editor:
+      preview: true
+    files:
+      - file: src/content/ki-news/index.json
+        label: KI News Daten
+        name: feed
+        fields:
+          - { name: lastUpdate, label: Letztes Update, widget: datetime }
+          - label: Artikel
+            name: articles
+            widget: list
+            summary: '{{fields.title}} – {{fields.source}}'
+            fields:
+              - { name: title, label: Titel, widget: string }
+              - { name: summary, label: Zusammenfassung, widget: text }
+              - { name: url, label: Quelle, widget: string }
+              - { name: source, label: Anbieter, widget: string }
+              - { name: publishedAt, label: Veröffentlich am, widget: datetime }
+              - { name: tags, label: Tags, widget: list, required: false }
+              - { name: relevanceScore, label: Relevanz (0-100), widget: number, min: 0, max: 100, value_type: int }
+          - label: Statistiken
+            name: stats
+            widget: object
+            fields:
+              - { name: totalFeeds, label: Eingelesene Feeds, widget: number }
+              - { name: totalArticles, label: Artikel gesamt, widget: number }
+              - { name: uniqueArticles, label: Einzigartige Artikel, widget: number }
+              - { name: finalArticles, label: Kuratierte Artikel, widget: number }

--- a/admin/index.html
+++ b/admin/index.html
@@ -4,14 +4,77 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>CMS – Alexander Schneider</title>
+    <meta
+      name="description"
+      content="Decap CMS Oberfläche für alexle135.de – Inhalte bearbeiten, Vorschauen prüfen und direkt via GitHub deployen."
+    />
     <style>
-      :root { color-scheme: light dark; }
-      body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif; }
-      .hint { position: fixed; inset: auto 1rem 1rem auto; opacity: .7; font-size: .875rem; }
+      :root {
+        color-scheme: light dark;
+        font-family: system-ui, -apple-system, "Segoe UI", Roboto, Ubuntu, Cantarell, "Noto Sans", sans-serif;
+        background: #0f172a;
+        color: #e2e8f0;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background: radial-gradient(circle at 20% 20%, rgba(148, 163, 184, 0.18), transparent 60%),
+          linear-gradient(135deg, rgba(30, 64, 175, 0.9), rgba(15, 23, 42, 0.95));
+      }
+      .cms-wrapper {
+        position: relative;
+        width: min(420px, 92vw);
+        padding: 2.5rem 2rem 2rem;
+        border-radius: 1.5rem;
+        background: rgba(15, 23, 42, 0.88);
+        backdrop-filter: blur(16px);
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        box-shadow: 0 30px 60px -35px rgba(15, 23, 42, 0.9);
+        text-align: center;
+      }
+      .cms-wrapper h1 {
+        margin: 0;
+        font-size: 1.65rem;
+        color: #f8fafc;
+      }
+      .cms-wrapper p {
+        font-size: 0.95rem;
+        line-height: 1.6;
+        color: rgba(226, 232, 240, 0.78);
+        margin-bottom: 1.5rem;
+      }
+      .cms-wrapper code {
+        font-family: "JetBrains Mono", Consolas, monospace;
+        background: rgba(15, 23, 42, 0.55);
+        padding: 0.25rem 0.45rem;
+        border-radius: 0.5rem;
+        color: #60a5fa;
+      }
+      .cms-hint {
+        margin-top: 1.5rem;
+        font-size: 0.85rem;
+        color: rgba(148, 163, 184, 0.85);
+      }
     </style>
   </head>
   <body>
-    <div class="hint">Decap CMS – Änderungen werden als Commits im Repo gespeichert.</div>
+    <div class="cms-wrapper">
+      <h1>Decap CMS</h1>
+      <p>
+        Änderungen werden versioniert in GitHub gespeichert. Nach dem Speichern erstellt GitHub Actions automatisch einen Deploy-Run
+        zum Server (rsync).
+      </p>
+      <p class="cms-hint">
+        Tipp: Vor dem Speichern rechts oben die Vorschau öffnen – dafür haben wir spezielle Templates für alle Content-Bereiche
+        hinterlegt.
+      </p>
+    </div>
+    <script>
+      window.CMS_MANUAL_INIT = true;
+    </script>
     <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
+    <script src="./preview-templates.js"></script>
   </body>
 </html>

--- a/admin/preview-templates.js
+++ b/admin/preview-templates.js
@@ -1,0 +1,366 @@
+(function () {
+  if (!window.CMS) {
+    return;
+  }
+
+  const CMS = window.CMS;
+  const React = CMS.React;
+  const h = React.createElement;
+
+  const previewStyles = `
+    :root {
+      color-scheme: light;
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    }
+    body {
+      margin: 0;
+      background: #f5f5f5;
+      color: #0f172a;
+    }
+    .cms-preview {
+      padding: 2.5rem clamp(1.5rem, 3vw, 3rem);
+      max-width: 960px;
+      margin: 0 auto;
+      display: grid;
+      gap: 1.75rem;
+    }
+    .preview-card {
+      background: white;
+      border-radius: 1rem;
+      padding: clamp(1.5rem, 3vw, 2rem);
+      box-shadow: 0 10px 35px -25px rgba(15, 23, 42, 0.4);
+      border: 1px solid rgba(148, 163, 184, 0.2);
+    }
+    .preview-card h1,
+    .preview-card h2,
+    .preview-card h3 {
+      margin-top: 0;
+      color: #0f172a;
+    }
+    .preview-card p {
+      color: #334155;
+      line-height: 1.6;
+    }
+    .preview-grid {
+      display: grid;
+      gap: 1rem;
+    }
+    .preview-grid--columns {
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+    .preview-badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.2rem 0.75rem;
+      border-radius: 999px;
+      background: #e2e8f0;
+      color: #0f172a;
+      font-size: 0.75rem;
+      font-weight: 600;
+      margin: 0.2rem;
+    }
+    .preview-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.75rem 1.5rem;
+      border-radius: 0.75rem;
+      background: #2563eb;
+      color: white;
+      font-weight: 600;
+      margin-top: 1.25rem;
+      width: fit-content;
+      box-shadow: 0 15px 30px -20px rgba(37, 99, 235, 0.6);
+    }
+    .media-preview {
+      margin-top: 1.5rem;
+      border-radius: 1rem;
+      overflow: hidden;
+      background: rgba(37, 99, 235, 0.08);
+      border: 1px dashed rgba(37, 99, 235, 0.3);
+      padding: 1rem;
+      text-align: center;
+      color: #1d4ed8;
+      font-weight: 500;
+    }
+    .media-preview img,
+    .media-preview video {
+      width: 100%;
+      max-height: 320px;
+      object-fit: cover;
+      border-radius: 0.75rem;
+    }
+    .stat-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: 1rem;
+    }
+    .stat-card {
+      background: #0f172a;
+      color: white;
+      border-radius: 0.85rem;
+      padding: 1rem 1.25rem;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+    }
+    .stat-card span {
+      display: block;
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      opacity: 0.65;
+      margin-bottom: 0.25rem;
+    }
+    .stat-card strong {
+      font-size: 1.5rem;
+      font-weight: 700;
+    }
+    .cms-markdown {
+      margin-top: 1.5rem;
+      display: grid;
+      gap: 1rem;
+      color: #1e293b;
+    }
+    .cms-markdown h2,
+    .cms-markdown h3 {
+      color: #0f172a;
+    }
+    .cms-markdown ul,
+    .cms-markdown ol {
+      padding-left: 1.25rem;
+    }
+    .cms-markdown blockquote {
+      border-left: 4px solid rgba(37, 99, 235, 0.25);
+      padding-left: 1rem;
+      color: #475569;
+      font-style: italic;
+    }
+    .preview-list {
+      display: grid;
+      gap: 1rem;
+      padding: 0;
+      margin: 0;
+      list-style: none;
+    }
+    .preview-list-item {
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      border-radius: 0.85rem;
+      padding: 1rem 1.25rem;
+      background: rgba(248, 250, 252, 0.95);
+    }
+    .progress {
+      width: 100%;
+      height: 8px;
+      border-radius: 999px;
+      background: rgba(148, 163, 184, 0.3);
+      overflow: hidden;
+      margin-top: 0.75rem;
+    }
+    .progress-bar {
+      height: 100%;
+      background: linear-gradient(90deg, #2563eb, #22d3ee);
+    }
+  `;
+
+  CMS.registerPreviewStyle(previewStyles, { raw: true });
+
+  const getData = (entry) => {
+    const data = entry && entry.get('data');
+    return data && data.toJS ? data.toJS() : {};
+  };
+
+  const resolveAsset = (props, path) => {
+    if (!path) return null;
+    const asset = props.getAsset(path);
+    if (asset && typeof asset.toString === 'function') {
+      return asset.toString();
+    }
+    return path;
+  };
+
+  const formatDateTime = (value) => {
+    if (!value) return '';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return value;
+    }
+    return date.toLocaleString('de-DE');
+  };
+
+  const HeroPreview = CMS.createClass({
+    render() {
+      const data = getData(this.props.entry);
+      const mediaUrl = resolveAsset(this.props, data.media);
+      return h('div', { className: 'cms-preview' },
+        h('section', { className: 'preview-card preview-card--hero' }, [
+          h('h1', { key: 'title' }, data.title || 'Hero Titel eingeben'),
+          data.subtitle && h('p', { key: 'subtitle' }, data.subtitle),
+          data.cta && h('div', { key: 'cta', className: 'preview-button' }, data.cta),
+          mediaUrl && h('div', { key: 'media', className: 'media-preview' },
+            data.media && data.media.endsWith('.mp4')
+              ? h('video', { src: mediaUrl, controls: true })
+              : h('img', { src: mediaUrl, alt: data.title || 'Hero Media' })
+          )
+        ])
+      );
+    }
+  });
+
+  const AboutPreview = CMS.createClass({
+    render() {
+      const data = getData(this.props.entry);
+      const imageUrl = resolveAsset(this.props, data.profileImage);
+      const body = this.props.widgetFor && this.props.widgetFor('body');
+      return h('div', { className: 'cms-preview' },
+        h('section', { className: 'preview-card preview-card--about' }, [
+          h('h1', { key: 'title' }, data.title || 'Titel eingeben'),
+          imageUrl && h('div', { key: 'image', className: 'media-preview' },
+            h('img', { src: imageUrl, alt: data.profileImageAlt || data.title || 'Profilbild' })
+          ),
+          body && h('div', { key: 'body', className: 'cms-markdown' }, body)
+        ])
+      );
+    }
+  });
+
+  const ServicesPreview = CMS.createClass({
+    render() {
+      const data = getData(this.props.entry);
+      const items = Array.isArray(data.items) ? data.items : [];
+      return h('div', { className: 'cms-preview' },
+        h('section', { className: 'preview-card preview-card--services' }, [
+          h('h1', { key: 'title' }, 'Services'),
+          h('div', { key: 'items', className: 'preview-grid preview-grid--columns' },
+            items.length
+              ? items.map((item, index) => h('article', { key: index, className: 'preview-list-item' }, [
+                  h('h3', { key: 'title' }, item.title || 'Service'),
+                  item.description && h('p', { key: 'description' }, item.description),
+                  item.tags && item.tags.length && h('div', { key: 'tags' },
+                    item.tags.map((tag, tagIndex) => h('span', { key: tagIndex, className: 'preview-badge' }, tag))
+                  )
+                ]))
+              : h('p', { key: 'empty' }, 'Noch keine Services angelegt.')
+          )
+        ])
+      );
+    }
+  });
+
+  const SkillsPreview = CMS.createClass({
+    render() {
+      const data = getData(this.props.entry);
+      const items = Array.isArray(data.items) ? data.items : [];
+      return h('div', { className: 'cms-preview' },
+        h('section', { className: 'preview-card preview-card--skills' }, [
+          h('h1', { key: 'title' }, 'Skills'),
+          h('div', { key: 'items', className: 'preview-grid preview-grid--columns' },
+            items.length
+              ? items.map((item, index) => h('article', { key: index, className: 'preview-list-item' }, [
+                  h('h3', { key: 'name' }, item.name || 'Skill'),
+                  item.category && h('span', { key: 'category', className: 'preview-badge' }, item.category),
+                  h('div', { key: 'progress', className: 'progress' },
+                    h('div', {
+                      className: 'progress-bar',
+                      style: { width: `${Math.min(Math.max(item.percentage || 0, 0), 100)}%` }
+                    })
+                  )
+                ]))
+              : h('p', { key: 'empty' }, 'Noch keine Skills angelegt.')
+          )
+        ])
+      );
+    }
+  });
+
+  const ProjectsPreview = CMS.createClass({
+    render() {
+      const data = getData(this.props.entry);
+      const imageUrl = resolveAsset(this.props, data.heroImage);
+      const body = this.props.widgetFor && this.props.widgetFor('body');
+      return h('div', { className: 'cms-preview' },
+        h('section', { className: 'preview-card preview-card--project' }, [
+          h('h1', { key: 'title' }, data.title || 'Projekt Titel'),
+          data.summary && h('p', { key: 'summary' }, data.summary),
+          (data.repo || data.demo) && h('div', { key: 'links' }, [
+            data.repo && h('span', { key: 'repo', className: 'preview-badge' }, 'Repo-Link hinterlegt'),
+            data.demo && h('span', { key: 'demo', className: 'preview-badge' }, 'Demo-Link hinterlegt')
+          ]),
+          imageUrl && h('div', { key: 'image', className: 'media-preview' },
+            h('img', { src: imageUrl, alt: data.title || 'Projektbild' })
+          ),
+          body && h('div', { key: 'body', className: 'cms-markdown' }, body)
+        ])
+      );
+    }
+  });
+
+  const LegalPreview = CMS.createClass({
+    render() {
+      const data = getData(this.props.entry);
+      const body = this.props.widgetFor && this.props.widgetFor('body');
+      return h('div', { className: 'cms-preview' },
+        h('section', { className: 'preview-card preview-card--legal' }, [
+          h('h1', { key: 'title' }, data.title || 'Rechtstext'),
+          body && h('div', { key: 'body', className: 'cms-markdown' }, body)
+        ])
+      );
+    }
+  });
+
+  const KiNewsPreview = CMS.createClass({
+    render() {
+      const data = getData(this.props.entry);
+      const articles = Array.isArray(data.articles) ? data.articles : [];
+      const stats = data.stats || {};
+      return h('div', { className: 'cms-preview' },
+        h('section', { className: 'preview-card preview-card--ki-news' }, [
+          h('h1', { key: 'title' }, 'KI News Feed'),
+          data.lastUpdate && h('p', { key: 'updated' }, `Stand: ${formatDateTime(data.lastUpdate)}`),
+          h('div', { key: 'stats', className: 'stat-grid' }, [
+            h('div', { key: 'totalFeeds', className: 'stat-card' }, [
+              h('span', { key: 'label' }, 'Feeds eingelesen'),
+              h('strong', { key: 'value' }, stats.totalFeeds ?? '–')
+            ]),
+            h('div', { key: 'totalArticles', className: 'stat-card' }, [
+              h('span', { key: 'label' }, 'Artikel gesamt'),
+              h('strong', { key: 'value' }, stats.totalArticles ?? '–')
+            ]),
+            h('div', { key: 'uniqueArticles', className: 'stat-card' }, [
+              h('span', { key: 'label' }, 'Einzigartige Artikel'),
+              h('strong', { key: 'value' }, stats.uniqueArticles ?? '–')
+            ]),
+            h('div', { key: 'finalArticles', className: 'stat-card' }, [
+              h('span', { key: 'label' }, 'Kuratierte Artikel'),
+              h('strong', { key: 'value' }, stats.finalArticles ?? '–')
+            ])
+          ]),
+          h('ul', { key: 'articles', className: 'preview-list' },
+            articles.length
+              ? articles.map((article, index) => h('li', { key: index, className: 'preview-list-item' }, [
+                  h('h3', { key: 'title' }, article.title || 'Artikel Titel'),
+                  article.summary && h('p', { key: 'summary' }, article.summary),
+                  h('div', { key: 'meta' }, [
+                    article.source && h('span', { key: 'source', className: 'preview-badge' }, article.source),
+                    article.publishedAt && h('span', { key: 'date', className: 'preview-badge' }, formatDateTime(article.publishedAt)),
+                    typeof article.relevanceScore === 'number' && h('span', { key: 'score', className: 'preview-badge' }, `Score: ${article.relevanceScore}`)
+                  ]),
+                  article.tags && article.tags.length && h('div', { key: 'tags' },
+                    article.tags.map((tag, tagIndex) => h('span', { key: tagIndex, className: 'preview-badge' }, tag))
+                  )
+                ]))
+              : h('li', { key: 'empty', className: 'preview-list-item' }, 'Noch keine Artikel vorhanden.')
+          )
+        ])
+      );
+    }
+  });
+
+  CMS.registerPreviewTemplate('hero', HeroPreview);
+  CMS.registerPreviewTemplate('about', AboutPreview);
+  CMS.registerPreviewTemplate('services', ServicesPreview);
+  CMS.registerPreviewTemplate('skills', SkillsPreview);
+  CMS.registerPreviewTemplate('projects', ProjectsPreview);
+  CMS.registerPreviewTemplate('legal', LegalPreview);
+  CMS.registerPreviewTemplate('ki-news', KiNewsPreview);
+
+  CMS.init();
+})();

--- a/docs/cms-content-workflow.md
+++ b/docs/cms-content-workflow.md
@@ -1,0 +1,59 @@
+# Content-Editing Workflow (Decap CMS)
+
+Diese Anleitung beschreibt den kompletten Redaktions-Workflow – von der Anmeldung im CMS bis zum veröffentlichten Inhalt auf
+der Live-Seite.
+
+## 1. Anmelden
+
+1. Rufe `https://alexle135.de/admin/` auf.
+2. Melde dich mit deinem GitHub-Account an (OAuth). Nach erfolgreichem Login erscheint das Decap Dashboard mit allen Collections.
+
+## 2. Inhalte bearbeiten
+
+1. Wähle in der linken Navigation die gewünschte Collection (z. B. **Projekte**, **Services**, **KI News**).
+2. Bei **Listen-Collections** (z. B. Projekte) kannst du über **"New"** neue Einträge erzeugen oder bestehende auswählen.
+3. Felder sind in Klartext beschrieben. Pflichtfelder sind markiert, optionale Felder können leer bleiben.
+4. Nutze das rechte Panel **Preview**, um die speziell vorbereiteten Vorschauen für jeden Content-Typ zu prüfen.
+
+## 3. Änderungen speichern
+
+- **Save** legt einen Draft an und erstellt einen Branch (`cms/<collection>/<slug>`). Ideal für Zwischenstände.
+- **Publish** (oben rechts) merged den Draft in `main`. Dadurch wird automatisch die GitHub Action zum Deployment gestartet.
+
+## 4. Medien verwalten
+
+1. Öffne in der Seitenleiste den Menüpunkt **Media**.
+2. Lade neue Bilder/Videos hoch – sie werden automatisch in `public/media/uploads` gespeichert.
+3. Über das Feld `media` bzw. `heroImage` lassen sich die Assets per Dropdown auswählen.
+
+## 5. Review-Prozess (Editorial Workflow)
+
+- Jeder Draft taucht im Tab **Review** auf.
+- Status wechseln per Buttons:
+  - **Draft** → **In Review** (wenn Kolleg:in prüfen soll)
+  - **In Review** → **Ready** (Freigabe)
+  - **Ready** → **Publish** (geht nach `main`)
+- Kommentare können direkt im GitHub Pull Request ergänzt werden (Decap legt automatisch einen PR an).
+
+## 6. Deployment & Kontrolle
+
+1. Nach dem Publish wartet ca. 2–3 Minuten, bis GitHub Actions den Build ausgeführt hat.
+2. Prüfe den Status unter `https://github.com/alexle135/alexle-vsco/actions`.
+3. Nach erfolgreichem Build werden die Dateien via rsync auf den Server kopiert.
+4. Öffne die Live-Seite und kontrolliere die Änderungen (Cache ggf. mit `Shift + Reload` leeren).
+
+## 7. Fehlerbehebung
+
+- **Login schlägt fehl**: OAuth-Proxy prüfen (`sudo systemctl status decap-oauth`).
+- **Medien erscheinen nicht**: Sicherstellen, dass die Datei im CMS als Asset gewählt wurde und nicht nur der Dateiname eingegeben
+  ist.
+- **Preview leer**: Pflichtfelder (Titel, Summary etc.) ergänzen – die Templates benötigen minimale Inhalte.
+
+## 8. Good Practices
+
+- Vor größeren Änderungen immer einen Draft speichern und Feedback einholen.
+- Markdown-Inhalte mit Überschriften strukturieren (`## Abschnitt`) – die Preview zeigt das später wie auf der Live-Seite.
+- Für rechtliche Texte (Impressum/Datenschutz) nur veröffentlichen, wenn juristisch geprüft.
+
+Mit diesem Workflow lassen sich alle Inhalte ohne lokale Entwicklungsumgebung pflegen. Änderungen bleiben nachvollziehbar, da
+jeder Schritt als Commit im Git-Verlauf landet.

--- a/docs/cms-github-oauth.md
+++ b/docs/cms-github-oauth.md
@@ -1,0 +1,98 @@
+# GitHub OAuth Setup für Decap CMS
+
+Diese Anleitung beschreibt, wie der Login ins Decap CMS über GitHub OAuth umgesetzt wird. Ziel ist, dass sich Redakteur:innen
+mit ihrem GitHub-Account anmelden und Änderungen automatisch als Commits im Repository `alexle135/alexle-vsco` landen.
+
+## Voraussetzungen
+
+- GitHub-Repository mit Schreibrechten (`alexle135/alexle-vsco`).
+- Live-Domain: `https://alexle135.de` (identisch mit `admin/config.yml`).
+- Zugriff auf den Zielserver, auf dem das OAuth-Proxy-Skript laufen soll.
+- Node.js ≥ 18 auf dem Server für das Decap Auth Proxy (`decap-server`).
+
+## 1. GitHub OAuth App anlegen
+
+1. Melde dich bei GitHub an und öffne **Settings → Developer settings → OAuth Apps**.
+2. Klicke auf **"New OAuth App"** und fülle folgende Felder aus:
+   - **Application name**: `Decap CMS alexle135.de`
+   - **Homepage URL**: `https://alexle135.de`
+   - **Authorization callback URL**: `https://alexle135.de/api/auth/callback`
+3. Nach dem Erstellen erhältst du eine **Client ID**. Generiere außerdem direkt ein **Client Secret**.
+4. Notiere beide Werte – sie werden als Umgebungsvariablen für den OAuth-Proxy benötigt.
+
+> ⚠️ Die Callback-URL muss exakt zum späteren Reverse-Proxy passen. Falls die Seite in einer Staging-Umgebung läuft,
+> dort entsprechend eine eigene OAuth App anlegen.
+
+## 2. OAuth Proxy mit `decap-server` bereitstellen
+
+Decap CMS benötigt bei GitHub immer einen kleinen Proxy, der die OAuth-Anmeldung handhabt. Der einfachste Weg ist das npm-Paket
+[`decap-server`](https://www.npmjs.com/package/decap-server).
+
+### Installation (Server)
+
+```bash
+npm install -g decap-server
+```
+
+### Service-Konfiguration
+
+1. Lege auf dem Server eine `.env` Datei an, z. B. `/opt/decap-oauth/.env`:
+   ```env
+   GITHUB_CLIENT_ID=<Client ID aus GitHub>
+   GITHUB_CLIENT_SECRET=<Client Secret aus GitHub>
+   GITHUB_REDIRECT_URI=https://alexle135.de/api/auth/callback
+   ORIGIN=https://alexle135.de
+   PORT=9000
+   ```
+2. Starte den Proxy testweise:
+   ```bash
+   decap-server --auth-type=github --port=${PORT:-9000}
+   ```
+   Die Ausgabe sollte `listening on http://0.0.0.0:9000` enthalten.
+
+### Reverse Proxy / Apache
+
+Der OAuth-Proxy wird anschließend über den Webserver erreichbar gemacht. Für Apache (vgl. bestehenden Deployment-Stack):
+
+```apacheconf
+ProxyPass        /api/auth http://127.0.0.1:9000/ retry=0 timeout=30
+ProxyPassReverse /api/auth http://127.0.0.1:9000/
+```
+
+Danach Apache neustarten (`sudo systemctl reload apache2`).
+
+## 3. Secrets in GitHub Actions hinterlegen
+
+Damit Deployments weiterhin funktionieren, sollten die OAuth-Credentials zusätzlich als Repository-Secrets abgelegt werden (z. B.
+`CMS_GITHUB_CLIENT_ID`, `CMS_GITHUB_CLIENT_SECRET`). Sie werden aktuell noch nicht im Build benötigt, dienen aber als Backup und
+können für automatisierte Tests genutzt werden.
+
+## 4. Lokales Testen
+
+Für lokale Redaktions-Tests kann der Proxy ebenfalls gestartet werden:
+
+```bash
+pnpm dlx decap-server --auth-type=github --port=8088
+```
+
+In `admin/config.yml` kann temporär `base_url: http://localhost:8088` gesetzt werden. Danach ist das CMS auf
+`http://localhost:4321/admin/` lauffähig.
+
+## 5. Abgleich mit `admin/config.yml`
+
+Die Datei [`admin/config.yml`](../admin/config.yml) ist bereits vorbereitet:
+
+```yaml
+backend:
+  name: github
+  repo: alexle135/alexle-vsco
+  branch: main
+  base_url: https://alexle135.de
+  auth_endpoint: api/auth
+```
+
+- **`base_url`** zeigt auf die Domain, auf der der OAuth-Proxy erreichbar ist.
+- **`auth_endpoint`** entspricht dem Apache-Proxy (`/api/auth`).
+
+Nach erfolgreichem Login legt Decap CMS Commits im `main`-Branch an und löst damit automatisch den bestehenden GitHub-Actions
+Workflow aus.

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,18 +1,88 @@
-import { z, defineCollection } from 'astro:content';
+import { defineCollection, z } from 'astro:content';
+
+const heroCollection = defineCollection({
+  type: 'data',
+  schema: z.object({
+    title: z.string(),
+    subtitle: z.string().optional(),
+    cta: z.string().optional(),
+    media: z.string().optional()
+  })
+});
+
+const aboutCollection = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    profileImage: z.string().optional(),
+    profileImageAlt: z.string().optional()
+  })
+});
+
+const servicesCollection = defineCollection({
+  type: 'data',
+  schema: z.object({
+    items: z.array(
+      z.object({
+        title: z.string(),
+        description: z.string(),
+        icon: z.string().optional(),
+        color: z.string().optional(),
+        tags: z.array(z.string()).optional()
+      })
+    )
+  })
+});
+
+const skillsCollection = defineCollection({
+  type: 'data',
+  schema: z.object({
+    items: z.array(
+      z.object({
+        name: z.string(),
+        percentage: z.number().min(0).max(100),
+        category: z.string().optional()
+      })
+    )
+  })
+});
+
+const projectsCollection = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    summary: z.string(),
+    date: z.string().optional(),
+    tags: z.array(z.string()).default([]),
+    heroImage: z.string().optional(),
+    repo: z.string().optional(),
+    demo: z.string().optional()
+  })
+});
+
+const legalCollection = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    bodyClass: z.string().optional()
+  })
+});
 
 const kiNewsCollection = defineCollection({
   type: 'data',
   schema: z.object({
     lastUpdate: z.string(),
-    articles: z.array(z.object({
-      title: z.string(),
-      summary: z.string(),
-      url: z.string().url(),
-      source: z.string(),
-      publishedAt: z.string(),
-      tags: z.array(z.string()),
-      relevanceScore: z.number().min(0).max(100)
-    })),
+    articles: z.array(
+      z.object({
+        title: z.string(),
+        summary: z.string(),
+        url: z.string().url(),
+        source: z.string(),
+        publishedAt: z.string(),
+        tags: z.array(z.string()),
+        relevanceScore: z.number().min(0).max(100)
+      })
+    ),
     stats: z.object({
       totalFeeds: z.number(),
       totalArticles: z.number(),
@@ -23,5 +93,11 @@ const kiNewsCollection = defineCollection({
 });
 
 export const collections = {
+  hero: heroCollection,
+  about: aboutCollection,
+  services: servicesCollection,
+  skills: skillsCollection,
+  projects: projectsCollection,
+  legal: legalCollection,
   'ki-news': kiNewsCollection
 };


### PR DESCRIPTION
## Summary
- switch Decap CMS to GitHub OAuth backend and model every Astro content collection
- add rich preview templates for hero, about, services, skills, projects, legal and KI news entries
- document GitHub OAuth proxy setup and the end-to-end editorial workflow for non-technical editors

## Testing
- pnpm lint *(fails: ESLint config missing in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68dee87bcc7c832895564669ff0e2b56